### PR TITLE
Add option to return findings from apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ redactable --policy gdpr.yaml input.log output.redacted.log
 from redactable import apply
 
 data = "Customer email: test@example.com"
-result = apply(data, policy="gdpr.yaml")
+result, findings = apply(data, policy="gdpr.yaml", return_findings=True)
 print(result)
 # → "Customer email: ****@example.com"
+print(findings[0])
+# → <Finding email value='test@example.com' conf=1.00>
 ````
 
 
@@ -75,9 +77,11 @@ print(result)
 from redactable import apply
 
 data = "Customer email: test@example.com"
-result = apply(data, policy="gdpr.yaml")
+result, findings = apply(data, policy="gdpr.yaml", return_findings=True)
 print(result)
 # → "Customer email: ****@example.com"
+print(findings[0])
+# → <Finding email value='test@example.com' conf=1.00>
 ````
 
 ### Pandas Integration

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -3,8 +3,11 @@
 _(Placeholder — auto-generated docs will be added in v0.2+.)_
 
 ## Core Functions
-### `apply(data, policy)`
-Apply redaction to input string or structured object using policy file.
+### `apply(data, policy, *, region="GB", return_findings=False)`
+Apply redaction to input string or structured object using a policy file.
+
+- Returns the transformed text by default.
+- If `return_findings=True`, returns `(text, findings)` so you can inspect detector output.
 
 ### `df.redact(policy)`
 Pandas DataFrame integration.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,9 +11,11 @@ redactable --policy gdpr.yaml input.log output.redacted.log
 from redactable import apply
 
 data = "Customer email: test@example.com"
-result = apply(data, policy="gdpr.yaml")
+result, findings = apply(data, policy="gdpr.yaml", return_findings=True)
 print(result)
 # → "Customer email: ****@example.com"
+print(findings[0])
+# → <Finding email value='test@example.com' conf=1.00>
 ```
 
 ## Pandas Integration

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -7,3 +7,22 @@ def test_apply_stub_masks_example_com():
     policy = PolicyBuilder(name="stub").mask("email", keep_tail=12, mask_glyph="*").build()
     out = apply(text, policy=policy)
     assert "****@example.com" in out
+
+
+def test_apply_can_return_findings():
+    text = "Customer email: test@example.com"
+    policy = (
+        PolicyBuilder(name="stub")
+        .mask("email", keep_tail=12, mask_glyph="*")
+        .build()
+    )
+    out, findings = apply(text, policy=policy, return_findings=True)
+    assert "****@example.com" in out
+    assert any(f.kind == "email" for f in findings)
+
+
+def test_apply_return_findings_without_policy():
+    text = "Customer email: test@example.com"
+    out, findings = apply(text, policy=None, return_findings=True)
+    assert out == text
+    assert any(f.kind == "email" for f in findings)


### PR DESCRIPTION
## Summary
- allow `apply` to optionally return detection findings alongside the transformed text via a new `return_findings` flag
- document the new flag across the README, quickstart, and API reference examples
- extend tests to cover returning findings with and without a policy

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc84e587d483248485fc63ba0fb0a2