### PR TITLE
Strengthen email detector test

### DIFF
--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -5,6 +5,7 @@ def test_email():
     text = "Contact: alice.smith+test@sub.example.co.uk and bad@mail"
     m = [x for x in run_all(text) if x.label == "EMAIL"]
     assert any("alice.smith+test@sub.example.co.uk" in x.value for x in m)
+    assert all("bad@mail" not in x.value for x in m)
 
 def test_credit_card_luhn():
     # Visa test PAN: 4111 1111 1111 1111


### PR DESCRIPTION
## Summary
- ensure the email detector test fails if the detector returns the known invalid address

## Testing
- PYTHONPATH=src pytest tests/test_detectors.py

------
https://chatgpt.com/codex/tasks/task_e_68cc98c504dc8324aeccaa8d5b4c5f42