### PR TITLE
Clarify default policy behaviour in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Organisations today face:
 - **Policy-first:** declarative, auditable YAML/JSON policies.  
 - **Cross-modal:** text, structured data, logs; extensible to images/audio later.  
 - **Pluggable:** detectors, transformations, integrations as plugins.  
-- **Safe defaults:** fail-closed behaviour (no silent leaks).  
+- **Safe defaults:** data stays unchanged unless a policy rule matches; add a catch-all rule when you need fail-closed behaviour.
 - **Enterprise-aligned:** GDPR, PCI, HIPAA compliance packs.  
 - **Developer-friendly:** CLI, Python SDK, Pandas integration.  
 
@@ -137,7 +137,7 @@ print(redacted)
 
 - Role-based redaction (analyst vs admin).
 
-- Fail-closed defaults.
+- Configurable fail-closed behaviour via catch-all policy rules.
 
 ### ✅ Integrations
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,4 +13,4 @@ Regex alone misses context and governance. Redactable combines regex, entropy de
 - Works locally, not cloud-only
 
 ### What happens if no policy matches?
-Fail-closed: unknown fields are **redacted by default**.
+Data is left unchanged unless a policy rule matches it. To guarantee fail-closed behaviour, add a final "catch-all" rule in your policy (for example, a regex that matches `.*` and redacts) so anything that slips past specific rules is still removed.

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -17,4 +17,5 @@ rules:
   - **Example:** Analyst sees masked, Admin sees tokenised.
 
 ## Safe Defaults
-- Fail-closed behaviour: if no matching policy → data is redacted.
+- By default, data is unchanged when no policy rule matches it.
+- To enforce fail-closed behaviour, add a catch-all rule (for example, a final regex such as `.*`) that redacts anything not matched by earlier, more specific rules.


### PR DESCRIPTION
## Summary
- update FAQ, policy documentation, and README to describe the default pass-through behaviour when no rules match
- add guidance on configuring catch-all rules for fail-closed enforcement

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc98c2f33083248cea7215392dc17a