### PR TITLE
Fix policy span adjustments across replacements

### DIFF
--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -26,3 +26,18 @@ def test_apply_return_findings_without_policy():
     out, findings = apply(text, policy=None, return_findings=True)
     assert out == text
     assert any(f.kind == "email" for f in findings)
+
+
+def test_apply_mixed_policy_handles_length_shifts():
+    text = "Email test@example.com and phone 07123456789."
+    policy = (
+        PolicyBuilder(name="mixed")
+        .redact("email")
+        .mask("phone", keep_head=2, keep_tail=2, mask_glyph="*")
+        .build()
+    )
+
+    out = apply(text, policy=policy)
+
+    assert "[REDACTED:EMAIL]" in out
+    assert "07*******89" in out


### PR DESCRIPTION
## Summary
- track cumulative offsets created by replacements and adjust spans before subsequent rules
- ensure redaction, masking, and tokenization replacements use updated coordinates
- add regression test covering mixed actions that previously misaligned spans

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc98c264ec8324b1f7e77cf5839b0f