### PR TITLE
Ensure pytest can import the redactable package

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ filterwarnings =
     error
     ignore::DeprecationWarning:pkg_resources
 testpaths = tests
+pythonpath = src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pip~=25.2
 pyyaml~=6.0.2
+pydantic~=2.11.7


### PR DESCRIPTION
## Summary
- configure pytest to include the src directory on sys.path so package imports work without installation
- add the missing pydantic dependency to requirements.txt so runtime imports succeed during tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cca146cba48324a626583f0768ce3b