### PR TITLE
Guard phone fallback from card matches

### DIFF
--- a/src/redactable/detectors/regexes.py
+++ b/src/redactable/detectors/regexes.py
@@ -104,6 +104,10 @@ RE_PHONE = re.compile(
     re.VERBOSE,
 )
 
+# Helpers to detect digit runs neighbouring phone candidates
+RE_PHONE_PREFIX_RUN = re.compile(r"(?:\d[\s-]?)+$")
+RE_PHONE_SUFFIX_RUN = re.compile(r"^(?:[\s-]?\d)+")
+
 class PhoneDetector:
     """Detect phone numbers via regex + optional libphonenumber."""
     name = "phone"
@@ -137,6 +141,30 @@ class PhoneDetector:
         # Fallback regex-only detection
         for m in RE_PHONE.finditer(text):
             raw = m.group(0)
+
+            # Skip obvious credit card numbers that happen to match
+            if RE_CARD.fullmatch(raw):
+                continue
+
+            start, end = m.span()
+            prefix_match = RE_PHONE_PREFIX_RUN.search(text, 0, start)
+            suffix_match = RE_PHONE_SUFFIX_RUN.match(text, end)
+
+            prefix_digits = (
+                sum(ch.isdigit() for ch in prefix_match.group())
+                if prefix_match
+                else 0
+            )
+            suffix_digits = (
+                sum(ch.isdigit() for ch in suffix_match.group())
+                if suffix_match
+                else 0
+            )
+
+            # Guard against slicing into digit runs (e.g. credit card groups)
+            if prefix_digits >= 4 or suffix_digits >= 4:
+                continue
+
             yield Finding(
                 kind=self.name,
                 value=raw,

--- a/src/redactable/detectors/regexes.py
+++ b/src/redactable/detectors/regexes.py
@@ -95,9 +95,11 @@ except Exception:  # pragma: no cover
 # Simple phone regex fallback
 RE_PHONE = re.compile(
     r"""
+    (?<!\d)                    # do not start in the middle of a digit run
     (?:\+\d{1,3}[\s-]?)?      # optional country code
     (?:\(?\d{2,4}\)?[\s-]?)?  # optional area code
     \d{3,4}[\s-]?\d{3,4}      # subscriber number
+    (?![\s-]?\d)              # ensure the number does not continue
     """,
     re.VERBOSE,
 )

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -13,6 +13,13 @@ def test_credit_card_luhn():
     m = [x for x in run_all(text) if x.label == "CREDIT_CARD"]
     assert len(m) == 1 and luhn_check('4111111111111111')
 
+
+def test_phone_fallback_does_not_truncate_card_numbers():
+    # Ensure fallback phone regex doesn't partially consume card numbers
+    text = "Card: 4111 1111 1111 1111"
+    phone_matches = [x for x in run_all(text) if x.label == "PHONE"]
+    assert phone_matches == []
+
 def test_iban():
     # Example GB: GB82 WEST 1234 5698 7654 32
     text = "Payout to IBAN GB82WEST12345698765432 today."


### PR DESCRIPTION
## Summary
- tighten the fallback phone regex with digit-run guards to avoid partially matching credit cards
- add regression test ensuring phone fallback does not redact card numbers

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68cca32bf48483248e1e0e2b69d856ab