### PR TITLE
Adjust credit card confidence based on brand

### DIFF
--- a/src/redactable/detectors/credit_card.py
+++ b/src/redactable/detectors/credit_card.py
@@ -24,13 +24,19 @@ class CreditCardDetector:
         for m in _PAN.finditer(text):
             raw = m.group(1)
             digits = ''.join(ch for ch in raw if ch.isdigit())
+            brand = _brand(digits)
             if 13 <= len(digits) <= 19 and luhn_check(digits):
+                confidence = 0.95
+                if brand:
+                    confidence = min(1.0, confidence + 0.03)
+                else:
+                    confidence = max(0.0, confidence - 0.03)
                 yield Match(
                     label="CREDIT_CARD",
                     start=m.start(1), end=m.end(1),
                     value=raw,
-                    confidence=0.98,
-                    meta={"digits": digits, "brand": _brand(digits)}
+                    confidence=confidence,
+                    meta={"digits": digits, "brand": brand}
                 )
 
 register(CreditCardDetector())

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -13,6 +13,22 @@ def test_credit_card_luhn():
     m = [x for x in run_all(text) if x.label == "CREDIT_CARD"]
     assert len(m) == 1 and luhn_check('4111111111111111')
 
+
+def test_credit_card_confidence_branding():
+    branded_text = "Card: 4111 1111 1111 1111"
+    branded = [x for x in run_all(branded_text) if x.label == "CREDIT_CARD"]
+    assert len(branded) == 1
+    branded_match = branded[0]
+    assert branded_match.meta["brand"] == "VISA"
+
+    unbranded_text = "Other: 6011 1111 1111 1117"
+    unbranded = [x for x in run_all(unbranded_text) if x.label == "CREDIT_CARD"]
+    assert len(unbranded) == 1
+    unbranded_match = unbranded[0]
+    assert unbranded_match.meta["brand"] is None
+
+    assert branded_match.confidence > unbranded_match.confidence
+
 def test_iban():
     # Example GB: GB82 WEST 1234 5698 7654 32
     text = "Payout to IBAN GB82WEST12345698765432 today."


### PR DESCRIPTION
## Summary
- derive credit card match confidence from both the Luhn check and detected brand metadata
- include the computed brand in match metadata without recomputation and adjust tests for branded vs unbranded PANs

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68cca3a01fa88324a38f9cdb7389cef7