### PR TITLE
Support user path expansion in policy loader

### DIFF
--- a/src/redactable/policy/loader.py
+++ b/src/redactable/policy/loader.py
@@ -19,7 +19,7 @@ def load_policy(path: str | Path) -> Policy:
         ValueError: if the file extension is unsupported
         pydantic.ValidationError: if the content does not match the schema
     """
-    p = Path(path)
+    p = Path(path).expanduser()
     if not p.exists():
         candidate = None
         if not p.is_absolute():
@@ -29,6 +29,8 @@ def load_policy(path: str | Path) -> Policy:
             p = candidate
         else:
             raise FileNotFoundError(f"Policy file not found: {p}")
+
+    p = p.resolve()
 
     text = p.read_text(encoding="utf-8")
     suffix = p.suffix.lower()

--- a/tests/test_policy_loader.py
+++ b/tests/test_policy_loader.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import json
+
+from redactable.policy.loader import load_policy
+
+
+def test_load_policy_expands_user_path(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+
+    policy_content = {
+        "version": 1,
+        "name": "test",
+        "description": "Test policy",
+        "rules": [
+            {
+                "id": "rule-email",
+                "field": "email",
+                "action": "redact",
+            }
+        ],
+    }
+    policy_path = home_dir / "policy.json"
+    policy_path.write_text(json.dumps(policy_content), encoding="utf-8")
+
+    policy = load_policy(Path("~/policy.json"))
+
+    assert policy.name == "test"


### PR DESCRIPTION
## Summary
- expand user paths before accessing policy files and resolve final path after fallback
- add a regression test ensuring load_policy handles user home paths

## Testing
- pytest tests/test_policy_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68cca866b6a0832488465d2a29bd7f5c