### PR TITLE
Use shared entropy utility and extend tests

### DIFF
--- a/src/redactable/detectors/entropy.py
+++ b/src/redactable/detectors/entropy.py
@@ -15,23 +15,6 @@ import re
 from .base import Match, register, Finding, Detector
 from .utils import shannon_entropy, looks_like_secret
 from typing import Iterable
-import math
-
-
-# --------------------------------------------------------------------
-# Helpers
-
-def shannon_entropy(s: str) -> float:
-    """
-    Calculate Shannon entropy of a string.
-    Returns a value >= 0, higher means more random.
-    """
-    if not s:
-        return 0.0
-    freq = {ch: s.count(ch) for ch in set(s)}
-    n = len(s)
-    return -sum((c/n) * math.log2(c/n) for c in freq.values())
-
 # --------------------------------------------------------------------
 # Regex pattern: matches candidate secrets
 BASELIKE_PATTERN = re.compile(

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -58,3 +58,13 @@ def test_entropy():
     text = f"api key: {likely}"
     m = [x for x in run_all(text) if x.label == "SECRET"]
     assert len(m) >= 1
+
+
+def test_entropy_long_random_string():
+    long_secret = (
+        "1972308aa69828cadf41f9ca7bf252715521bb76b1762fa3da47c41076d422a0"
+        "856177c1a70fbd759c8c4a820748a21c07abab0989749afaf391b279a5c67aae"
+    )
+    text = f"token={long_secret}"
+    matches = [x for x in run_all(text) if x.label == "SECRET"]
+    assert any(long_secret in x.value for x in matches)


### PR DESCRIPTION
## Summary
- remove the local Shannon entropy implementation so the detector uses the shared utility
- add a regression test that exercises detection on a long random secret string

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cca883d2f08324908bc022ff4f6ff1