### PR TITLE
Implement redactable IO decorator and add tests

### DIFF
--- a/src/redactable/decors.py
+++ b/src/redactable/decors.py
@@ -1,1 +1,56 @@
-def redactable_io(policy): . . .
+"""Decorator helpers for applying redactable policies to callables."""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, ParamSpec, TypeVar
+
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def redactable_io(
+    policy: Any,
+    *,
+    region: str = "GB",
+    return_findings: bool = False,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Wrap a callable so its string output is processed by :func:`apply`.
+
+    The decorator executes the wrapped callable first and, when the returned
+    value is a string, runs :func:`redactable.apply` with the provided policy
+    and region. Non-string return values are passed through unchanged. This
+    keeps the decorator flexible for functions that sometimes return metadata
+    objects or ``None``.
+
+    Args:
+        policy: Policy specification accepted by :func:`redactable.apply`.
+        region: Region hint forwarded to the detector registry.
+        return_findings: When ``True`` the decorated callable will return the
+            tuple ``(text, findings)`` produced by :func:`apply`.
+    """
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            result = func(*args, **kwargs)
+
+            if not isinstance(result, str):
+                return result
+
+            from redactable import apply as _apply  # Local import to avoid cycle.
+
+            return _apply(
+                result,
+                policy=policy,
+                region=region,
+                return_findings=return_findings,
+            )
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+__all__ = ["redactable_io"]

--- a/tests/test_decors.py
+++ b/tests/test_decors.py
@@ -1,0 +1,35 @@
+from redactable.decors import redactable_io
+from redactable.policy import PolicyBuilder
+
+
+def sample_policy():
+    return PolicyBuilder(name="email-policy").redact("email").build()
+
+
+def test_redactable_io_redacts_output():
+    @redactable_io(policy=sample_policy())
+    def build_message(address: str) -> str:
+        return f"Contact me at {address}"
+
+    output = build_message("test@example.com")
+    assert "[REDACTED:EMAIL]" in output
+
+
+def test_redactable_io_passes_through_non_string():
+    data = {"email": "test@example.com"}
+
+    @redactable_io(policy=sample_policy())
+    def get_data():
+        return data
+
+    assert get_data() is data
+
+
+def test_redactable_io_can_return_findings():
+    @redactable_io(policy=sample_policy(), return_findings=True)
+    def build_message(address: str) -> str:
+        return f"Contact me at {address}"
+
+    output, findings = build_message("test@example.com")
+    assert "[REDACTED:EMAIL]" in output
+    assert any(f.kind == "email" for f in findings)


### PR DESCRIPTION
## Summary
- implement the redactable_io decorator to wrap callables and automatically apply redactable policies to string outputs
- export the decorator and ensure non-string outputs pass through unchanged
- add unit tests covering redaction, passthrough behaviour, and returning findings from the decorator

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cca85f506083248fadae84af6b7ac9