### PR TITLE
Add JSONL record writing support to AuditJSONLWriter

### DIFF
--- a/src/redactable/in_out/writers.py
+++ b/src/redactable/in_out/writers.py
@@ -19,6 +19,12 @@ class StdoutWriter(Writer):
 class AuditJSONLWriter(Writer):
     def __init__(self, path: str):
         self._f = open(path, "w", encoding="utf-8")
+
+    def write_record(self, record: Record) -> None:
+        event = dict(record.meta)
+        event["content"] = record.content
+        self.write_event(event)
+
     def write_event(self, event: dict) -> None:
         self._f.write(json.dumps(event, ensure_ascii=False) + "\n")
     def close(self): self._f.close()

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+from redactable.in_out.base import Record
+from redactable.in_out.writers import AuditJSONLWriter
+
+
+def test_audit_jsonl_writer_writes_records(tmp_path: Path) -> None:
+    path = tmp_path / "audit.jsonl"
+    writer = AuditJSONLWriter(str(path))
+    record = Record("redacted text", meta={"id": "123", "tags": ["a", "b"]})
+
+    writer.write_record(record)
+    writer.close()
+
+    contents = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(contents) == 1
+    event = json.loads(contents[0])
+    assert event["id"] == "123"
+    assert event["tags"] == ["a", "b"]
+    assert event["content"] == "redacted text"
+
+
+def test_audit_jsonl_writer_can_write_raw_events(tmp_path: Path) -> None:
+    path = tmp_path / "audit.jsonl"
+    writer = AuditJSONLWriter(str(path))
+
+    writer.write_event({"custom": True})
+    writer.close()
+
+    contents = path.read_text(encoding="utf-8").strip()
+    assert json.loads(contents) == {"custom": True}


### PR DESCRIPTION
## Summary
- add a write_record implementation for AuditJSONLWriter that serializes Record content and metadata
- keep write_event for raw dict emission while reusing the same file handle
- introduce tests covering both record-based and raw event JSONL output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cca852c6e48324a25545e225000fbc