### PR TITLE
feat(policy): support rule where predicates

### DIFF
--- a/src/redactable/policy/builder.py
+++ b/src/redactable/policy/builder.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Iterable, Iterator
+from typing import Iterable, Iterator, TYPE_CHECKING
 
 from .model import Policy, Rule
+
+
+if TYPE_CHECKING:  # pragma: no cover - for typing only
+    from .model import RuleWhere
 
 
 class PolicyBuilder:
@@ -59,6 +63,7 @@ class PolicyBuilder:
         *,
         id: str | None = None,
         replacement: str | None = None,
+        where: dict[str, object] | "RuleWhere" | None = None,
     ) -> "PolicyBuilder":
         """Append a redact rule."""
 
@@ -68,6 +73,8 @@ class PolicyBuilder:
         }
         if replacement is not None:
             data["replacement"] = replacement
+        if where is not None:
+            data["where"] = where
         return self.rule(id=id, **data)
 
     def mask(
@@ -78,6 +85,7 @@ class PolicyBuilder:
         keep_head: int | None = None,
         keep_tail: int | None = None,
         mask_glyph: str | None = None,
+        where: dict[str, object] | "RuleWhere" | None = None,
     ) -> "PolicyBuilder":
         """Append a mask rule."""
 
@@ -91,6 +99,8 @@ class PolicyBuilder:
             data["keep_tail"] = keep_tail
         if mask_glyph is not None:
             data["mask_glyph"] = mask_glyph
+        if where is not None:
+            data["where"] = where
         return self.rule(id=id, **data)
 
     def tokenize(
@@ -99,6 +109,7 @@ class PolicyBuilder:
         *,
         id: str | None = None,
         salt: str | None = None,
+        where: dict[str, object] | "RuleWhere" | None = None,
     ) -> "PolicyBuilder":
         """Append a tokenize rule."""
 
@@ -108,6 +119,8 @@ class PolicyBuilder:
         }
         if salt is not None:
             data["salt"] = salt
+        if where is not None:
+            data["where"] = where
         return self.rule(id=id, **data)
 
     def extend(self, rules: Iterable[Rule]) -> "PolicyBuilder":

--- a/src/redactable/policy/engine.py
+++ b/src/redactable/policy/engine.py
@@ -90,6 +90,8 @@ def apply_policy(policy: Policy, findings: list[Finding], text: str) -> str:
 
     for rule in policy.rules:
         targets = by_kind.get(rule.field, [])
+        if rule.where is not None:
+            targets = [f for f in targets if rule.applies_to(f)]
         if not targets:
             continue
 

--- a/src/redactable/policy/model.py
+++ b/src/redactable/policy/model.py
@@ -1,18 +1,157 @@
 # ruff: noqa: E402
 from __future__ import annotations
-from typing import Literal, Optional
-from pydantic import BaseModel, Field, field_validator
+
+import re
+from typing import TYPE_CHECKING, Any, Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+if TYPE_CHECKING:  # pragma: no cover - typing helpers
+    from redactable.detectors import Finding
 
 Action = Literal["redact", "mask", "tokenize"]
 
+class MetadataPredicate(BaseModel):
+    """Constraint applied to a metadata value in :class:`Finding` extras."""
+
+    equals: Any | None = Field(default=None, description="Value must equal this literal")
+    matches: str | None = Field(
+        default=None,
+        description="Value must match this regular expression (string values only)",
+    )
+
+    @field_validator("matches")
+    @classmethod
+    def _validate_regex(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        try:
+            re.compile(v)
+        except re.error as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Invalid regex pattern: {exc}") from exc
+        return v
+
+    @model_validator(mode="after")
+    def _check_any(self) -> "MetadataPredicate":
+        if self.equals is None and self.matches is None:
+            raise ValueError("metadata predicate requires 'equals' and/or 'matches'")
+        return self
+
+    def applies(self, value: Any) -> bool:
+        if self.equals is not None and value != self.equals:
+            return False
+        if self.matches is not None:
+            if not isinstance(value, str):
+                return False
+            if re.search(self.matches, value) is None:
+                return False
+        return True
+
+
+class RuleWhere(BaseModel):
+    """Optional filters applied before executing a :class:`Rule`."""
+
+    min_confidence: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Lower confidence bound for matched findings",
+    )
+    max_confidence: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Upper confidence bound for matched findings",
+    )
+    value_matches: str | None = Field(
+        default=None,
+        description="Regex that the finding value must match",
+    )
+    normalized_matches: str | None = Field(
+        default=None,
+        description="Regex that the normalized value must match",
+    )
+    metadata: dict[str, MetadataPredicate] | None = Field(
+        default=None,
+        description="Mapping of metadata keys to predicates that must pass",
+    )
+
+    @field_validator("value_matches", "normalized_matches")
+    @classmethod
+    def _validate_regex(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        try:
+            re.compile(v)
+        except re.error as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Invalid regex pattern: {exc}") from exc
+        return v
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _coerce_metadata(
+        cls, value: Optional[dict[str, Any | MetadataPredicate]]
+    ) -> Optional[dict[str, MetadataPredicate]]:
+        if value is None:
+            return None
+        result: dict[str, MetadataPredicate] = {}
+        for key, predicate in value.items():
+            if isinstance(predicate, MetadataPredicate):
+                result[key] = predicate
+            elif isinstance(predicate, dict):
+                result[key] = MetadataPredicate(**predicate)
+            else:
+                result[key] = MetadataPredicate(equals=predicate)
+        return result
+
+    @model_validator(mode="after")
+    def _ensure_any(self) -> "RuleWhere":
+        if (
+            self.min_confidence is None
+            and self.max_confidence is None
+            and self.value_matches is None
+            and self.normalized_matches is None
+            and not self.metadata
+        ):
+            raise ValueError("where clause must define at least one predicate")
+        if (
+            self.min_confidence is not None
+            and self.max_confidence is not None
+            and self.min_confidence > self.max_confidence
+        ):
+            raise ValueError("min_confidence cannot be greater than max_confidence")
+        return self
+
+    def applies(self, finding: "Finding") -> bool:
+        if self.min_confidence is not None and finding.confidence < self.min_confidence:
+            return False
+        if self.max_confidence is not None and finding.confidence > self.max_confidence:
+            return False
+        if self.value_matches is not None and re.search(self.value_matches, finding.value) is None:
+            return False
+        if self.normalized_matches is not None:
+            norm = finding.normalized or ""
+            if not norm or re.search(self.normalized_matches, norm) is None:
+                return False
+        if self.metadata:
+            extras = finding.extras or {}
+            for key, predicate in self.metadata.items():
+                if key not in extras:
+                    return False
+                if not predicate.applies(extras[key]):
+                    return False
+        return True
+
+
 class Rule(BaseModel):
-    """
-    One transformation applied to all Findings whose kind == field.
-    Future: add 'where' filters (regex, confidence threshold, etc.).
-    """
+    """One transformation applied to all Findings whose ``kind`` matches ``field``."""
     id: str = Field(..., description="Rule identifier (unique within policy)")
     field: str = Field(..., description="Detector kind (e.g. email, credit_card, phone)")
     action: Action = Field(..., description="Transformation to apply")
+    where: RuleWhere | None = Field(
+        default=None,
+        description="Optional predicates limiting which findings are transformed",
+    )
 
     # Redact options
     replacement: Optional[str] = Field(
@@ -39,6 +178,11 @@ class Rule(BaseModel):
         if v is not None and v.strip() == "":
             raise ValueError("replacement cannot be empty; use None to default")
         return v
+
+    def applies_to(self, finding: "Finding") -> bool:
+        if self.where is None:
+            return True
+        return self.where.applies(finding)
 
 class Policy(BaseModel):
     """

--- a/tests/test_policy_builder.py
+++ b/tests/test_policy_builder.py
@@ -38,3 +38,13 @@ def test_policy_factory_recreates_rules():
     # Different instances should be produced each time (no shared list)
     policy_one.rules[0].replacement = "changed"
     assert policy_two.rules[0].replacement == "[secure]"
+
+
+def test_policy_builder_accepts_where_clause():
+    builder = PolicyBuilder(name="filters")
+    builder.redact("email", where={"min_confidence": 0.8})
+
+    policy = builder.build()
+
+    assert policy.rules[0].where is not None
+    assert policy.rules[0].where.min_confidence == 0.8

--- a/tests/test_policy_where.py
+++ b/tests/test_policy_where.py
@@ -1,0 +1,103 @@
+import pytest
+
+from redactable.detectors import Finding
+from redactable.policy import Policy, Rule
+from redactable.policy.engine import apply_policy
+
+
+def test_rule_where_filters_by_confidence():
+    text = "a@b.com z@x.com"
+    findings = [
+        Finding(kind="email", value="a@b.com", span=(0, 7), confidence=0.95),
+        Finding(kind="email", value="z@x.com", span=(8, 15), confidence=0.5),
+    ]
+    policy = Policy(
+        version=1,
+        name="conf",
+        rules=[
+            Rule(
+                id="redact-high-confidence",
+                field="email",
+                action="redact",
+                where={"min_confidence": 0.9},
+            )
+        ],
+    )
+
+    out = apply_policy(policy, findings, text)
+
+    assert "[REDACTED:EMAIL]" in out
+    assert "z@x.com" in out
+
+
+def test_rule_where_filters_by_value_regex():
+    text = "Contact: a@example.com or z@test.dev"
+    findings = [
+        Finding(kind="email", value="a@example.com", span=(9, 22), confidence=0.9),
+        Finding(kind="email", value="z@test.dev", span=(26, 36), confidence=0.9),
+    ]
+    policy = Policy(
+        version=1,
+        name="regex",
+        rules=[
+            Rule(
+                id="mask-example-domain",
+                field="email",
+                action="mask",
+                keep_tail=4,
+                mask_glyph="*",
+                where={"value_matches": r"@example\.com$"},
+            )
+        ],
+    )
+
+    out = apply_policy(policy, findings, text)
+
+    assert "z@test.dev" in out
+    assert "@example.com" not in out
+    assert "*********.com" in out
+
+
+def test_rule_where_filters_on_metadata():
+    text = "4111 1111 1111 1111 and 5555 5555 5555 4444"
+    findings = [
+        Finding(
+            kind="credit_card",
+            value="4111 1111 1111 1111",
+            span=(0, 19),
+            confidence=0.85,
+            normalized="4111111111111111",
+            extras={"brand": "visa"},
+        ),
+        Finding(
+            kind="credit_card",
+            value="5555 5555 5555 4444",
+            span=(24, 43),
+            confidence=0.85,
+            normalized="5555555555554444",
+            extras={"brand": "mastercard"},
+        ),
+    ]
+    policy = Policy(
+        version=1,
+        name="metadata",
+        rules=[
+            Rule(
+                id="tokenize-visa",
+                field="credit_card",
+                action="tokenize",
+                salt="pepper",
+                where={"metadata": {"brand": "visa"}},
+            )
+        ],
+    )
+
+    out = apply_policy(policy, findings, text)
+
+    assert "5555 5555 5555 4444" in out
+    assert "visa" not in out
+
+
+def test_rule_where_invalid_regex_raises_validation_error():
+    with pytest.raises(ValueError):
+        Rule(id="bad", field="email", action="redact", where={"value_matches": "["})


### PR DESCRIPTION
## Summary
- add `Rule.where` predicates for confidence ranges, regex matches, and metadata constraints
- teach the policy builder and engine to accept and honour the new where clauses
- add unit tests covering builder wiring and rule filtering behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccaa82917083248eb0b4f330f56ab5