### PR TITLE
Implement schema hint detection from context

### DIFF
--- a/src/redactable/detectors/schema_hints.py
+++ b/src/redactable/detectors/schema_hints.py
@@ -77,6 +77,10 @@ def _iter_schema_fields(schema) -> Iterable[tuple[str, object]]:
             if key in _CONTAINER_KEYS:
                 continue
             results.append((str(key), value))
+            if isinstance(value, Mapping):
+                results.extend(_iter_schema_fields(value))
+            elif isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray, str)):
+                results.extend(_iter_schema_fields(value))
         return results
 
     if isinstance(schema, str):
@@ -94,6 +98,7 @@ def _iter_schema_fields(schema) -> Iterable[tuple[str, object]]:
                 )
                 if name:
                     results.append((str(name), item))
+                    results.extend(_iter_schema_fields(item))
                 else:
                     results.extend(_iter_schema_fields(item))
             elif isinstance(item, str):

--- a/src/redactable/detectors/schema_hints.py
+++ b/src/redactable/detectors/schema_hints.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+
 from .base import Match, register
 
 # This detector relies on context = {"schema": {"field_name": "value", ...}}
@@ -20,11 +25,114 @@ _HINTS = {
 class SchemaHintDetector:
     name = "schema_hints"
     labels = tuple(set(_HINTS.values()))
+    confidence = 0.6
 
     def detect(self, text: str, *, context=None):
-        # No-op for raw text. This detector is meant for structured rows.
-        # We still implement the signature; integrate at the DataFrame layer.
-        return
-        yield  # generator stub
+        schema = (context or {}).get("schema")
+        if not schema:
+            return []
+
+        matches: list[Match] = []
+        seen_fields: set[str] = set()
+
+        for field_name, raw in _iter_schema_fields(schema):
+            canonical = _canonical_name(field_name)
+            if not canonical or canonical in seen_fields:
+                continue
+            label = _label_for_field(canonical)
+            if not label:
+                continue
+            seen_fields.add(canonical)
+            meta = {"source": "schema", "field": field_name}
+            if raw is not None:
+                meta["schema_meta"] = raw
+            matches.append(
+                Match(
+                    label=label,
+                    start=0,
+                    end=0,
+                    value=str(field_name),
+                    confidence=self.confidence,
+                    meta=meta,
+                )
+            )
+        return matches
 
 register(SchemaHintDetector())
+
+
+_CONTAINER_KEYS = {"fields", "columns", "schema", "properties"}
+
+
+def _iter_schema_fields(schema) -> Iterable[tuple[str, object]]:
+    if schema is None:
+        return []
+
+    if isinstance(schema, Mapping):
+        results: list[tuple[str, object]] = []
+        for key in _CONTAINER_KEYS:
+            if key in schema and key not in _HINTS:
+                results.extend(_iter_schema_fields(schema[key]))
+        for key, value in schema.items():
+            if key in _CONTAINER_KEYS:
+                continue
+            results.append((str(key), value))
+        return results
+
+    if isinstance(schema, str):
+        return [(schema, None)]
+
+    if isinstance(schema, Iterable) and not isinstance(schema, (bytes, bytearray)):
+        results = []
+        for item in schema:
+            if isinstance(item, Mapping):
+                name = (
+                    item.get("name")
+                    or item.get("field")
+                    or item.get("column")
+                    or item.get("key")
+                )
+                if name:
+                    results.append((str(name), item))
+                else:
+                    results.extend(_iter_schema_fields(item))
+            elif isinstance(item, str):
+                results.append((item, None))
+            elif isinstance(item, Iterable) and not isinstance(item, (bytes, bytearray)):
+                sequence = list(item)
+                if sequence:
+                    results.append((str(sequence[0]), item))
+            else:
+                name = getattr(item, "name", None)
+                if name:
+                    results.append((str(name), item))
+        return results
+
+    return [(str(schema), None)]
+
+
+_CAMEL_RE = re.compile(r"([a-z0-9])([A-Z])")
+
+
+def _canonical_name(field_name: str) -> str:
+    field = str(field_name)
+    field = _CAMEL_RE.sub(r"\1_\2", field)
+    field = re.sub(r"[^a-zA-Z0-9]+", "_", field)
+    field = field.strip("_")
+    field = re.sub(r"_+", "_", field)
+    return field.lower()
+
+
+def _label_for_field(canonical: str) -> str | None:
+    if not canonical:
+        return None
+    if canonical in _HINTS:
+        return _HINTS[canonical]
+
+    parts = [p for p in canonical.split("_") if p]
+    for i in range(len(parts)):
+        for j in range(i + 1, len(parts) + 1):
+            candidate = "_".join(parts[i:j])
+            if candidate in _HINTS:
+                return _HINTS[candidate]
+    return None

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -162,3 +162,38 @@ def test_schema_hints_handles_nested_iterables():
 
     assert phone_match.value == "PHONE_NUMBER"
     assert phone_match.meta["schema_meta"] == {"name": "PHONE_NUMBER"}
+
+
+def test_schema_hints_recurses_into_named_mappings():
+    context = {
+        "schema": {
+            "fields": [
+                {
+                    "name": "customer",
+                    "fields": [
+                        {"name": "customerEmail"},
+                        {"name": "customer_ssn"},
+                    ],
+                }
+            ]
+        }
+    }
+
+    matches = [m for m in run_all("", context=context) if m.label in {"EMAIL", "SSN"}]
+    assert {m.value for m in matches} == {"customerEmail", "customer_ssn"}
+
+
+def test_schema_hints_recurses_into_nested_mappings():
+    context = {
+        "schema": {
+            "schema": {
+                "customer": {
+                    "Email": {"type": "string"},
+                    "phone": {"type": "string"},
+                }
+            }
+        }
+    }
+
+    matches = [m for m in run_all("", context=context) if m.label in {"EMAIL", "PHONE"}]
+    assert {m.value for m in matches} == {"Email", "phone"}

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -1,3 +1,5 @@
+import pytest
+
 from redactable.detectors.run import run_all
 from redactable.detectors.utils import nhs_check, luhn_check, iban_check
 
@@ -75,3 +77,46 @@ def test_entropy_long_random_string():
     text = f"token={long_secret}"
     matches = [x for x in run_all(text) if x.label == "SECRET"]
     assert any(long_secret in x.value for x in matches)
+
+
+def test_schema_hints_from_context_schema_mapping():
+    context = {
+        "schema": {
+            "Email": {"type": "string"},
+            "user_id": {"type": "uuid"},
+            "cardNumber": {"type": "string"},
+            "notes": {"type": "text"},
+        }
+    }
+
+    matches = [m for m in run_all("", context=context) if m.label in {"EMAIL", "CREDIT_CARD"}]
+    assert {m.value for m in matches} == {"Email", "cardNumber"}
+    for match in matches:
+        assert match.start == 0 and match.end == 0
+        assert match.meta["source"] == "schema"
+        assert match.meta["field"] in {"Email", "cardNumber"}
+        assert match.confidence == pytest.approx(0.6)
+
+
+def test_schema_hints_handles_nested_iterables():
+    context = {
+        "schema": {
+            "fields": [
+                {"name": "customerDOB"},
+                {"name": "PHONE_NUMBER"},
+                {"name": "address"},
+            ]
+        }
+    }
+
+    matches = [m for m in run_all("", context=context) if m.label in {"DATE_DOB", "PHONE"}]
+    assert len(matches) == 2
+
+    dob_match = next(m for m in matches if m.label == "DATE_DOB")
+    phone_match = next(m for m in matches if m.label == "PHONE")
+
+    assert dob_match.value == "customerDOB"
+    assert dob_match.meta["schema_meta"] == {"name": "customerDOB"}
+
+    assert phone_match.value == "PHONE_NUMBER"
+    assert phone_match.meta["schema_meta"] == {"name": "PHONE_NUMBER"}


### PR DESCRIPTION
## Summary
- add schema-aware detection logic that inspects contextual schemas for sensitive column hints
- normalise field names (including camelCase) and extract metadata for schema-derived matches
- extend detector tests to cover schema hint detection on mappings and nested iterable schemas

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccab1a92e483248c7373089a14a4cc