### PR TITLE
Adjust libphonenumber spans and add regression test

### DIFF
--- a/src/redactable/detectors/regexes.py
+++ b/src/redactable/detectors/regexes.py
@@ -120,9 +120,40 @@ class PhoneDetector:
             # Preferred: use Google's libphonenumber
             for m in phonenumbers.PhoneNumberMatcher(text, self.default_region):
                 num = m.number
-                norm = phonenumbers.format_number(
-                    num, phonenumbers.PhoneNumberFormat.E164
-                )
+                start, end = m.start, m.end
+
+                # Trim leading punctuation (e.g. "(") and trailing noise so the
+                # span/value cover just the phone number starting at the first
+                # plus or digit and ending on the final digit.
+                trim_start = start
+                while trim_start < end and not (
+                    text[trim_start] == "+" or text[trim_start].isdigit()
+                ):
+                    trim_start += 1
+
+                trim_end = end
+                while trim_end > trim_start and not text[trim_end - 1].isdigit():
+                    trim_end -= 1
+
+                if trim_start >= trim_end:
+                    continue
+
+                value = text[trim_start:trim_end]
+                digits = digits_only(value)
+                if not digits:
+                    continue
+
+                normalized = ("+" if value.startswith("+") else "") + digits
+                try:
+                    formatted = phonenumbers.format_number(
+                        num, phonenumbers.PhoneNumberFormat.E164
+                    )
+                except Exception:
+                    formatted = None
+                else:
+                    if formatted and digits_only(formatted) == digits:
+                        normalized = formatted
+
                 conf = 0.95 if phonenumbers.is_valid_number(num) else 0.6
                 extras = {
                     "region": phonenumbers.region_code_for_number(num),
@@ -130,10 +161,10 @@ class PhoneDetector:
                 }
                 yield Finding(
                     kind=self.name,
-                    value=text[m.start : m.end],
-                    span=(m.start, m.end),
+                    value=value,
+                    span=(trim_start, trim_end),
                     confidence=conf,
-                    normalized=norm,
+                    normalized=normalized,
                     extras=extras,
                 )
             return

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -1,5 +1,8 @@
+from types import SimpleNamespace
+
 from redactable.detectors.run import run_all
 from redactable.detectors.utils import nhs_check, luhn_check, iban_check
+from redactable.detectors import regexes
 
 def test_email():
     text = "Contact: alice.smith+test@sub.example.co.uk and bad@mail"
@@ -20,7 +23,47 @@ def test_phone_fallback_does_not_truncate_card_numbers():
     phone_matches = [x for x in run_all(text) if x.label == "PHONE"]
     assert phone_matches == []
 
-    
+
+def test_phone_libphonenumber_span_trimming(monkeypatch):
+    text = " phone (+07123…"
+    plus_index = text.index("+")
+    ellipsis_index = text.index("…")
+    fake_number = object()
+
+    class FakePhoneNumberMatcher:
+        def __init__(self, text_arg, region):
+            assert text_arg == text
+            assert region == "GB"
+            self._match = SimpleNamespace(
+                start=plus_index - 1,  # include leading "("
+                end=ellipsis_index,
+                number=fake_number,
+            )
+
+        def __iter__(self):
+            yield self._match
+
+    fake_phonenumbers = SimpleNamespace(
+        PhoneNumberMatcher=FakePhoneNumberMatcher,
+        PhoneNumberFormat=SimpleNamespace(E164="E164"),
+        format_number=lambda num, fmt: "+07123",
+        is_valid_number=lambda num: True,
+        region_code_for_number=lambda num: "GB",
+        number_type=lambda num: "MOBILE",
+    )
+
+    monkeypatch.setattr(regexes, "phonenumbers", fake_phonenumbers)
+
+    detector = regexes.PhoneDetector()
+    findings = list(detector.detect(text))
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.value == "+07123"
+    assert finding.span == (plus_index, ellipsis_index)
+    assert finding.normalized.endswith("07123")
+
+
 def test_credit_card_confidence_branding():
     branded_text = "Card: 4111 1111 1111 1111"
     branded = [x for x in run_all(branded_text) if x.label == "CREDIT_CARD"]


### PR DESCRIPTION
## Summary
- trim libphonenumber-derived phone spans to begin at the first plus/digit and end on the last digit
- keep normalized values aligned with trimmed digits while retaining metadata from libphonenumber
- add a regression test covering span trimming via a monkeypatched libphonenumber matcher

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ccad963f0083248a25037691510976