### PR TITLE
Make schema hint labels deterministic

### DIFF
--- a/src/redactable/detectors/schema_hints.py
+++ b/src/redactable/detectors/schema_hints.py
@@ -24,7 +24,7 @@ _HINTS = {
 
 class SchemaHintDetector:
     name = "schema_hints"
-    labels = tuple(set(_HINTS.values()))
+    labels = tuple(dict.fromkeys(_HINTS.values()))
     confidence = 0.6
 
     def detect(self, text: str, *, context=None):


### PR DESCRIPTION
## Summary
- ensure `SchemaHintDetector.labels` preserves hint insertion order by using `dict.fromkeys`

## Testing
- pytest tests/test_detectors.py -k schema_hints

------
https://chatgpt.com/codex/tasks/task_e_68cd5f42de88832492d48432346dcadb