### PR TITLE
Deduplicate optional dependency imports in regex detectors

### DIFF
--- a/src/redactable/detectors/regexes.py
+++ b/src/redactable/detectors/regexes.py
@@ -86,11 +86,6 @@ class CreditCardDetector:
                 extras={"luhn_valid": ok, "brand": brand},
             )
 
-try:
-    import phonenumbers  # type: ignore
-except Exception:  # pragma: no cover
-    phonenumbers = None
-
 # --------------------------------------------------------------------
 # Simple phone regex fallback
 RE_PHONE = re.compile(
@@ -277,13 +272,6 @@ class EmailDetector:
                 normalized=norm,
                 extras=extras,
             )
-
-try:
-    from stdnum import iban as std_iban  # type: ignore
-    from stdnum.gb import nhs as std_nhs  # type: ignore
-    from stdnum.us import ssn as std_us_ssn  # type: ignore
-except Exception:  # pragma: no cover
-    std_iban = std_nhs = std_us_ssn = None
 
 # --------------------------------------------------------------------
 # Regex patterns


### PR DESCRIPTION
## Summary
- keep a single set of optional dependency imports for email, phone, and stdnum helpers in regex detectors
- remove redundant fallback assignments so detectors consistently use the module-level imports

## Testing
- pytest tests/test_detectors.py

------
https://chatgpt.com/codex/tasks/task_e_68cd5f3fae2483249bbf5ef8caa906c0