### PR TITLE
Ensure schema hint labels order is deterministic

### DIFF
--- a/src/redactable/detectors/schema_hints.py
+++ b/src/redactable/detectors/schema_hints.py
@@ -24,7 +24,7 @@ _HINTS = {
 
 class SchemaHintDetector:
     name = "schema_hints"
-    labels = tuple(set(_HINTS.values()))
+    labels = tuple(dict.fromkeys(_HINTS.values()))
     confidence = 0.6
 
     def detect(self, text: str, *, context=None):


### PR DESCRIPTION
## Summary
- update SchemaHintDetector.labels to preserve the insertion order of hint labels for deterministic behaviour

## Testing
- pytest tests/test_detectors.py -k schema_hints

------
https://chatgpt.com/codex/tasks/task_e_68cd6071f26483248819bd48b0922f81