### PR TITLE
Refine detector protocol context signature

### DIFF
--- a/src/redactable/detectors/credit_card.py
+++ b/src/redactable/detectors/credit_card.py
@@ -1,4 +1,6 @@
 import re
+from typing import Any, Iterable, Optional
+
 from .base import Match, register
 from .utils import luhn_check
 
@@ -20,7 +22,12 @@ class CreditCardDetector:
     name = "credit_card"
     labels = ("CREDIT_CARD",)
 
-    def detect(self, text: str, *, context=None):
+    def detect(
+        self,
+        text: str,
+        *,
+        context: Optional[dict[str, Any]] = None,
+    ) -> Iterable[Match]:
         for m in _PAN.finditer(text):
             raw = m.group(1)
             digits = ''.join(ch for ch in raw if ch.isdigit())

--- a/src/redactable/detectors/email.py
+++ b/src/redactable/detectors/email.py
@@ -1,5 +1,7 @@
 import re
-from .base import Match, Detector, register
+from typing import Any, Iterable, Optional
+
+from .base import Match, register
 
 _EMAIL = re.compile(
     r'(?<![A-Za-z0-9._%+-])'     # left boundary
@@ -13,7 +15,12 @@ class EmailDetector:
     name = "email"
     labels = ("EMAIL",)
 
-    def detect(self, text: str, *, context=None):
+    def detect(
+        self,
+        text: str,
+        *,
+        context: Optional[dict[str, Any]] = None,
+    ) -> Iterable[Match]:
         for m in _EMAIL.finditer(text):
             yield Match(label="EMAIL", start=m.start(1), end=m.end(1), value=m.group(1), confidence=0.95)
 

--- a/src/redactable/detectors/entropy.py
+++ b/src/redactable/detectors/entropy.py
@@ -12,9 +12,10 @@ Intended as a complement to regex-based detectors.
 """
 
 import re
-from .base import Match, register, Finding, Detector
+from typing import Any, Iterable, Optional
+
+from .base import Match, register, Finding
 from .utils import shannon_entropy, looks_like_secret
-from typing import Iterable
 # --------------------------------------------------------------------
 # Regex pattern: matches candidate secrets
 BASELIKE_PATTERN = re.compile(
@@ -45,7 +46,12 @@ class HighEntropyTokenDetector:
         self.entropy_threshold = entropy_threshold
         self.min_len = min_len
 
-    def detect(self, text: str) -> Iterable[Finding]:
+    def detect(
+        self,
+        text: str,
+        *,
+        context: Optional[dict[str, Any]] = None,
+    ) -> Iterable[Finding]:
         """
         Scan text for high-entropy sequences.
         Yields Finding objects for each match.
@@ -76,7 +82,12 @@ class EntropyDetector:
     def __init__(self, *, threshold: float = 3.5):
         self.threshold = threshold
 
-    def detect(self, text: str, *, context=None):
+    def detect(
+        self,
+        text: str,
+        *,
+        context: Optional[dict[str, Any]] = None,
+    ) -> Iterable[Match]:
         threshold = (context or {}).get("entropy_threshold", self.threshold)
         for m in _TOKEN.finditer(text):
             token = m.group(1)

--- a/src/redactable/detectors/iban.py
+++ b/src/redactable/detectors/iban.py
@@ -1,4 +1,6 @@
 import re
+from typing import Any, Iterable, Optional
+
 from .base import Match, register
 from .utils import iban_check
 
@@ -8,7 +10,12 @@ class IBANDetector:
     name = "iban"
     labels = ("IBAN",)
 
-    def detect(self, text: str, *, context=None):
+    def detect(
+        self,
+        text: str,
+        *,
+        context: Optional[dict[str, Any]] = None,
+    ) -> Iterable[Match]:
         for m in _IBAN.finditer(text):
             token = m.group(1).upper()
             if iban_check(token):

--- a/src/redactable/detectors/nhs.py
+++ b/src/redactable/detectors/nhs.py
@@ -1,4 +1,6 @@
 import re
+from typing import Any, Iterable, Optional
+
 from .base import Match, register
 from .utils import nhs_check
 
@@ -9,7 +11,12 @@ class NHSDetector:
     name = "nhs"
     labels = ("NHS_NUMBER",)
 
-    def detect(self, text: str, *, context=None):
+    def detect(
+        self,
+        text: str,
+        *,
+        context: Optional[dict[str, Any]] = None,
+    ) -> Iterable[Match]:
         for m in _NHS.finditer(text):
             raw = m.group(1)
             digits = ''.join(ch for ch in raw if ch.isdigit())

--- a/src/redactable/detectors/phone.py
+++ b/src/redactable/detectors/phone.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
+
 import re
+from typing import Any, Iterable, Optional
+
 from .base import Match, register
 
 # E.164 (+441234567890), simple UK patterns (07..., 01/02... with spaces)
@@ -10,7 +13,12 @@ class PhoneDetector:
     name = "phone"
     labels = ("PHONE",)
 
-    def detect(self, text: str, *, context=None):
+    def detect(
+        self,
+        text: str,
+        *,
+        context: Optional[dict[str, Any]] = None,
+    ) -> Iterable[Match]:
         for m in _E164.finditer(text):
             yield Match("PHONE", m.start(1), m.end(1), m.group(1), 0.9, {"format": "E164"})
         for m in _UK.finditer(text):

--- a/src/redactable/detectors/run.py
+++ b/src/redactable/detectors/run.py
@@ -1,11 +1,12 @@
-from typing import Optional
+from typing import Any, Optional
+
 from .base import Match, all_detectors
 
 # Force registration even if package __init__ is bypassed
 # (pytest imports run_all directly in tests)
 from . import email, credit_card, iban, nhs, ssn, phone, entropy, schema_hints  # noqa: F401
 
-def run_all(text: str, *, context: Optional[dict] = None) -> list[Match]:
+def run_all(text: str, *, context: Optional[dict[str, Any]] = None) -> list[Match]:
     matches: list[Match] = []
     for det in all_detectors():
         for m in det.detect(text, context=context):

--- a/src/redactable/detectors/schema_hints.py
+++ b/src/redactable/detectors/schema_hints.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable, Mapping
+from typing import Any, Optional
 
 from .base import Match, register
 
@@ -27,7 +28,12 @@ class SchemaHintDetector:
     labels = tuple(set(_HINTS.values()))
     confidence = 0.6
 
-    def detect(self, text: str, *, context=None):
+    def detect(
+        self,
+        text: str,
+        *,
+        context: Optional[dict[str, Any]] = None,
+    ) -> Iterable[Match]:
         schema = (context or {}).get("schema")
         if not schema:
             return []

--- a/src/redactable/detectors/ssn.py
+++ b/src/redactable/detectors/ssn.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
+
 import re
+from typing import Any, Iterable, Optional
+
 from .base import Match, register
 
 _SSN = re.compile(r'(?<!\d)(\d{3}-?\d{2}-?\d{4})(?!\d)')
@@ -16,7 +19,12 @@ class SSNDetector:
     name = "ssn"
     labels = ("SSN",)
 
-    def detect(self, text: str, *, context=None):
+    def detect(
+        self,
+        text: str,
+        *,
+        context: Optional[dict[str, Any]] = None,
+    ) -> Iterable[Match]:
         for m in _SSN.finditer(text):
             raw = m.group(1)
             if _valid_ssn(raw):


### PR DESCRIPTION
## Summary
- document the detector protocol in `base.py` and collapse duplicate definitions
- standardise all registered detectors on the `detect(text, *, context=None)` signature that returns `Match`
- update the run helper to pass typed context dictionaries

## Testing
- `pytest tests/test_detectors.py`


------
https://chatgpt.com/codex/tasks/task_e_68cd606f6fd883248b385153c59bcecd