### PR TITLE
fix(policy): resolve circular import blocking package import

### DIFF
--- a/src/redactable/policy/engine.py
+++ b/src/redactable/policy/engine.py
@@ -6,7 +6,7 @@ from typing import Literal, overload
 
 from redactable.audit import AuditEvent, generate_audit_event
 from redactable.detectors import Finding
-from redactable.policy import Policy
+from redactable.policy.model import Policy
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
`redactable.policy.engine` imports `Policy` back from `redactable.policy`, but `redactable/policy/__init__.py` imports `engine` before it gets to defining/importing `Policy` itself. That circular reference means `import redactable` currently raises:

```
ImportError: cannot import name 'Policy' from partially initialized module 'redactable.policy' (most likely due to a circular import)
```

This isn't a corner case — it fails on a plain `import redactable`, and it was blocking pytest from even collecting `test_apply.py`, `test_policy_engine.py`, `test_policy_loader.py`, and `test_transforms.py`.

## Fix
Import `Policy` directly from `redactable.policy.model` (where it's actually defined) instead of re-importing it through the package `__init__`.

## Type
- [x] Bug fix

## Testing
- `import redactable` now succeeds.
- `pytest tests/test_apply.py tests/test_policy_loader.py tests/test_transforms.py` — all pass (these previously failed to even collect).
- `ruff check src/redactable/policy/engine.py` — clean.
- `mypy src/redactable/policy/engine.py` — clean.

Note: a few unrelated tests (`test_detectors.py`, `test_pandas_integration.py`, `test_policy_engine.py`'s audit-event tests) fail for separate, pre-existing reasons (e.g. `datetime.utcnow()` deprecation warnings promoted to errors, and Finding attribute mismatches) that were previously masked by the collection error. Left those out of scope to keep this fix focused and easy to review.

## Checklist
- [x] Tests added/updated (existing regression coverage now actually runs)
- [ ] Docs updated (not applicable, internal import fix)
- [x] Pre-commit hooks passed locally
- [x] Lint/typecheck passed (ruff, mypy)
- [x] Backwards compatible
- [ ] Changelog entry added